### PR TITLE
Refactor CLI parsing into struct and constructor impl

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,14 +6,30 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     println!("{:?}", args);
 
-    let query = &args[1];
-    let filename = &args[2];
+    let config = Config::new(&args);
 
-    let mut f = File::open(filename).expect("file not found"); // panic if file not found with custom message
+    let mut f = File::open(config.filename).expect("file not found"); // panic if file not found with custom message
 
     let mut contents = String::new();
     f.read_to_string(&mut contents)
         .expect("something went wrong reading the file"); // panic if file can't read for whatever reasons, with custom message
 
     print!("With text:\n{}", contents);
+}
+
+struct Config {
+    // use a struct instead of tuple to make return structure meaningful from parse_config ()
+    query: String,
+    filename: String,
+}
+
+impl Config {
+    // Constructor for Config
+    fn new(args: &[String]) -> Config {
+        // Using clone() to avoid ownership issue here; a small performance price to pay to make program more readable (for now)
+        let query = args[1].clone();
+        let filename = args[2].clone();
+
+        Config { query, filename }
+    }
 }


### PR DESCRIPTION
1. Refactor CLI arguments parsing into separate implementation from main() function.
2. Separate implementation takes the form of Config struct with a constructor implementation to make CLI arguments relatable and contextualized for the rgrep purpose - having a query string and a file from which to find the query string.